### PR TITLE
Added NoAnswerBOT to bot usernames

### DIFF
--- a/common/src/envs/constants.ts
+++ b/common/src/envs/constants.ts
@@ -180,7 +180,8 @@ export const BOT_USERNAMES = [
   'ShrimpLute',
   'kbot',
   'ataribot',
-  'RISKBOT'
+  'RISKBOT',
+  'NoAnswerBOT'
 ]
 
 export const MOD_IDS = [


### PR DESCRIPTION
Adds the @NoAnswerBOT account to the list of recognized bot accounts.

Also, if possible, can someone add the @NoAnswerBOT to the Silicon league as well? Thanks.